### PR TITLE
Allow output_frame to be set via dynamic-reconfigure

### DIFF
--- a/ar_track_alvar/cfg/Params.cfg
+++ b/ar_track_alvar/cfg/Params.cfg
@@ -11,6 +11,7 @@ gen.add("max_frequency", double_t, 0, "Maximum processing rate; frames coming at
 gen.add("marker_size", double_t, 0, "The width in centimeters of one side of the black square marker border", 10.0, 1.0, 100.0)
 gen.add("max_new_marker_error", double_t, 0, "A threshold determining when new markers can be detected under uncertainty", 0.08, 0.0, 2.0)
 gen.add("max_track_error", double_t, 0, "A threshold determining how much tracking error can be observed before an tag is considered to have disappeared", 0.2, 0.0, 4.0)
+gen.add("output_frame", str_t, 0, "The frame in which to publish the tag pose", "")
 
 # Second arg is node name it will run in (doc purposes only), third is generated filename prefix
 exit(gen.generate(PACKAGE, "ar_track_alvar_configure", "Params"))

--- a/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
+++ b/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
@@ -82,6 +82,11 @@ void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg)
 {
     //If we've already gotten the cam info, then go ahead
     if(cam->getCamInfo_){
+        if (output_frame.empty()) {
+            ROS_ERROR_THROTTLE(1, "Param 'output_frame' has to be set for the tag pose to be published.");
+            return;
+        }
+
         try{
             tf::StampedTransform CamToOutput;
             try{
@@ -228,6 +233,10 @@ void configCallback(ar_track_alvar::ParamsConfig &config, uint32_t level)
   marker_size = config.marker_size;
   max_new_marker_error = config.max_new_marker_error;
   max_track_error = config.max_track_error;
+  if (!config.output_frame.empty())
+  {
+    output_frame = config.output_frame;
+  }
 }
 
 void enableCallback(const std_msgs::BoolConstPtr& msg)
@@ -279,10 +288,6 @@ int main(int argc, char *argv[])
     pn.setParam("max_frequency", max_frequency);  // in case it was not set.
     pn.param("marker_resolution", marker_resolution, 5);
     pn.param("marker_margin", marker_margin, 2);
-    if (!pn.getParam("output_frame", output_frame)) {
-      ROS_ERROR("Param 'output_frame' has to be set.");
-      exit(EXIT_FAILURE);
-    }
 
     // Camera input topics. Use remapping to map to your camera topics.
     cam_image_topic = "camera_image";


### PR DESCRIPTION
 * If it is _not_ unspecified (or specified as the empty string) in the
   dynamic-reconfigure call, it will keep its current value. (This will
   allow output_frame to be passed in on the command line rather than
   passed in as a ROS parameter.)
 * If it has not been set by the time it is needed, then throw a
   (throttled) error message to the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ar_track_alvar/2)
<!-- Reviewable:end -->
